### PR TITLE
Support aliases

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   "dependencies": {
     "jsx-dom": "^5.1.2",
     "pluralize": "^6.0.0",
+    "remove-accents": "^0.4.0",
     "seamless-immutable": "^7.1.2"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "dependencies": {
     "jsx-dom": "^5.1.2",
     "pluralize": "^6.0.0",
-    "remove-accents": "^0.4.0",
+    "remove-accents": "tyxla/remove-accents#8025d6cd35900226f6c1d4dd709ad653fb74357b",
     "seamless-immutable": "^7.1.2"
   },
   "devDependencies": {

--- a/src/core/__tests__/findAllMatches.js
+++ b/src/core/__tests__/findAllMatches.js
@@ -149,3 +149,36 @@ test('Should detect plurals', (t) => {
     },
   ]);
 });
+
+test('Should detect aliases', (t) => {
+  const text = 'Frost, Yen, YenCon, QG and light cavalries';
+  const matchedRanges = findAllMatches(DICTIONARY, text);
+  t.deepEqual(matchedRanges, [
+    {
+      entryKey: 'frost',
+      entryValue: 'Biting Frost',
+      start: 0,
+      end: 5,
+    }, {
+      entryKey: 'yen',
+      entryValue: 'Yennefer',
+      start: 7,
+      end: 10,
+    }, {
+      entryKey: 'yencon',
+      entryValue: 'Yennefer: The Conjurer',
+      start: 12,
+      end: 18,
+    }, {
+      entryKey: 'qg',
+      entryValue: 'Queensguard',
+      start: 20,
+      end: 22,
+    }, {
+      entryKey: 'light cavalries',
+      entryValue: 'Dun Banner Light Cavalry',
+      start: 27,
+      end: 42,
+    },
+  ]);
+});

--- a/src/core/__tests__/findAllMatches.js
+++ b/src/core/__tests__/findAllMatches.js
@@ -151,7 +151,7 @@ test('Should detect plurals', (t) => {
 });
 
 test('Should detect aliases', (t) => {
-  const text = 'Frost, Yen, YenCon, QG and light cavalries, Schirru';
+  const text = 'Frost, Yen, YenCon, QG and light cavalries';
   const matchedRanges = findAllMatches(DICTIONARY, text);
   t.deepEqual(matchedRanges, [
     {

--- a/src/core/__tests__/findAllMatches.js
+++ b/src/core/__tests__/findAllMatches.js
@@ -151,7 +151,7 @@ test('Should detect plurals', (t) => {
 });
 
 test('Should detect aliases', (t) => {
-  const text = 'Frost, Yen, YenCon, QG and light cavalries';
+  const text = 'Frost, Yen, YenCon, QG and light cavalries, Schirru';
   const matchedRanges = findAllMatches(DICTIONARY, text);
   t.deepEqual(matchedRanges, [
     {
@@ -179,6 +179,19 @@ test('Should detect aliases', (t) => {
       entryValue: 'Dun Banner Light Cavalry',
       start: 27,
       end: 42,
+    },
+  ]);
+});
+
+test('Should work around accentuated letters', (t) => {
+  const text = 'Schirru';
+  const matchedRanges = findAllMatches(DICTIONARY, text);
+  t.deepEqual(matchedRanges, [
+    {
+      entryKey: 'schirru',
+      entryValue: 'Schirrú',
+      start: 0,
+      end: 7,
     },
   ]);
 });

--- a/src/core/data/ALIASES.js
+++ b/src/core/data/ALIASES.js
@@ -4,7 +4,7 @@ const ALIASES = {
   ],
   Aelirenn: [],
   Aeromancy: [],
-  Aglais: [],
+  Aglaïs: [],
   'Alba Pikeman': [
     'pikeman',
   ],
@@ -532,7 +532,7 @@ const ALIASES = {
   'Savage Bear': [
     'bear',
   ],
-  Schirru: [],
+  Schirrú: [],
   Scorch: [],
   Serrit: [],
   Shadow: [],
@@ -542,7 +542,7 @@ const ALIASES = {
     'skaggs',
   ],
   Sigrdrifa: [],
-  'Sile de Tansarville': [
+  'Síle de Tansarville': [
     'sile',
   ],
   'Skellige Storm': [

--- a/src/core/data/ALIASES.js
+++ b/src/core/data/ALIASES.js
@@ -1,0 +1,682 @@
+const ALIASES = {
+  'Adrenaline Rush': [
+    'arush',
+  ],
+  Aelirenn: [],
+  Aeromancy: [],
+  Aglais: [],
+  'Alba Pikeman': [
+    'pikeman',
+  ],
+  'Alba Spearmen': [
+    'spearmen',
+  ],
+  Albrich: [],
+  Alchemist: [],
+  "Alzur's Double Cross": [
+    'adc',
+  ],
+  "Alzur's Thunder": [
+    'thunder',
+    'zap',
+  ],
+  Ambassador: [],
+  'Ancient Foglet': [
+    // 'af',
+  ],
+  Arachas: [],
+  'Arachas Behemoth': [
+    'behemoth',
+  ],
+  'Arachas Venom': [
+    // 'av',
+  ],
+  Archgriffin: [],
+  'Aretuza Adept': [
+    // 'aa',
+  ],
+  Assassination: [],
+  'Assire Var Anahid': [
+    'assire',
+  ],
+  Auckes: [],
+  "Avallac'h": [
+    'avallach',
+  ],
+  Ballista: [],
+  'Barclay Els': [
+    'barclay',
+  ],
+  "Bekker's Twisted Mirror": [
+    'btm',
+    'bekker',
+  ],
+  'Berserker Marauder': [
+    // 'bm',
+  ],
+  'Birna Bran': [
+    'birna',
+  ],
+  'Biting Frost': [
+    'frost',
+  ],
+  'Black Infantry Arbalest': [
+    'arbalest',
+  ],
+  'Bloodcurdling Roar': [
+    // 'br',
+  ],
+  'Bloody Baron': [
+    'baron',
+  ],
+  'Blue Mountain Commando': [
+    'bmc',
+  ],
+  'Blue Stripes Commando': [
+    'bsc',
+  ],
+  'Blue Stripes Scout': [
+    'bss',
+  ],
+  'Blueboy Lugos': [
+    'bluefish',
+  ],
+  Botchling: [],
+  Braenn: [],
+  'Brouver Hoog': [
+    'brouver',
+  ],
+  Cahir: [],
+  Cantarella: [],
+  Caranthir: [],
+  Caretaker: [],
+  Ceallach: [],
+  'Celaeno Harpy': [
+    // 'harpy',
+  ],
+  Cerys: [],
+  'Champion of Champions': [
+    'coc',
+  ],
+  Chort: [],
+  Ciaran: [],
+  Ciri: [],
+  'Ciri: Dash': [
+    'cdash',
+  ],
+  'Clan an Craite Raider': [
+    'ccr',
+    'raider',
+    'cacr',
+  ],
+  'Clan An Craite Warcrier': [
+    'warcrier',
+    // 'warcry',
+    'cacw',
+  ],
+  'Clan An Craite Warrior': [],
+  'Clan Brokvar Archer': [
+    'cba',
+  ],
+  'Clan Brokvar Hunter': [
+    'cbh',
+  ],
+  'Clan Dimun Pirate': [
+    'cdp',
+  ],
+  'Clan Dimun Pirate Captain': [
+    'cdpc',
+  ],
+  'Clan Drummond Shieldmaiden': [
+    'cds',
+  ],
+  'Clan Heymaey Skald': [
+    'skald',
+  ],
+  'Clan Tordarroch Armorsmith': [
+    'armorsmith',
+  ],
+  'Clan Tordarroch Shieldsmith': [
+    'shieldsmith',
+  ],
+  'Clan Tuirseach Axeman': [
+    'axeman',
+    'xman',
+    'xmen',
+  ],
+  'Clan Tuirseach Skirmishers': [
+    'skirmisher',
+  ],
+  Cleaver: [],
+  'Combat Engineer': [
+    'engineer',
+  ],
+  "Commander's Horn": [
+    // 'ch',
+    'horn',
+  ],
+  'Commando Neophyte': [
+    'neophyte',
+  ],
+  Coral: [],
+  'Crach An Craite': [
+    'crach',
+  ],
+  'Crone: Brewess': [
+    'brewess',
+  ],
+  'Crone: Weavess': [
+    'weavess',
+  ],
+  'Crone: Whispess': [
+    'whispess',
+  ],
+  Cynthia: [],
+  'Cyprian Wiley': [
+    'wiley',
+    'cyprian',
+    'whoreson',
+  ],
+  'Daerlan Foot Soldiers': [
+    'dfs',
+  ],
+  Dagon: [],
+  Dandelion: [],
+  Decoy: [],
+  'Dennis Cranmer': [
+    'dennis',
+    'cranmer',
+  ],
+  Dethmold: [],
+  Dijkstra: [],
+  'Dimeritium Bomb': [
+    'dbomb',
+  ],
+  'Dimeritium Shackles': [
+    'shackles',
+    'dshackles',
+    'lock',
+  ],
+  'Djenge Frett': [
+    'djenge',
+    'frett',
+  ],
+  'Dol Blathanna Archer': [
+    'dba',
+  ],
+  'Dol Blathanna Marksman': [
+    'dbm',
+  ],
+  'Dol Blathanna Protector': [
+    'dbp',
+    'protector',
+  ],
+  'Dol Blathanna Trapper': [
+    'trapper',
+  ],
+  'Donar an Hindar': [
+    'donar',
+    'hindar',
+  ],
+  'Draig Bon–Dhu': [
+    'draig',
+    'bon-dhu',
+  ],
+  Draug: [],
+  Drought: [],
+  Drowner: [],
+  Dudu: [],
+  'Dun Banner Heavy Cavalry': [
+    'dbhc',
+    'heavy cavalry',
+  ],
+  'Dun Banner Light Cavalry': [
+    'dblc',
+    'light cavalry',
+  ],
+  'Dwarven Mercenary': [],
+  'Dwarven Skirmisher': [],
+  'Earth Elemental': [],
+  Eithné: [
+    'eithne',
+  ],
+  Ekimmara: [
+    'eki',
+  ],
+  "Ele'yas": [
+    'eleyas',
+  ],
+  'Elven Mercenary': [
+    'merc',
+  ],
+  'Elven Wardancer': [
+    'wardancer',
+  ],
+  'Emhyr Var Emreis': [
+    'emhyr',
+  ],
+  Emissary: [],
+  Epidemic: [],
+  Eredin: [],
+  Ermion: [],
+  Eskel: [],
+  'Fake Ciri': [],
+  'Field Medic': [
+    // 'fm',
+  ],
+  Fiend: [],
+  'Fire Elemental': [],
+  'Fire Scorpion': [
+    // 'fs',
+    'scorpion',
+  ],
+  'First Light': [
+    // 'fl',
+  ],
+  Foglet: [],
+  Foltest: [],
+  Francesca: [],
+  Frightener: [],
+  'Fringilla Vigo': [
+    'fringilla',
+  ],
+  "Gaunter O'Dimm": [
+    'gaunter',
+    'god',
+  ],
+  "Ge'els": [
+    'geels',
+  ],
+  Geralt: [],
+  'Geralt: Aard': [
+    'aard',
+    'gaard',
+  ],
+  'Geralt: Igni': [
+    'igni',
+    'gigni',
+  ],
+  Ghoul: [],
+  'Giant Toad': [
+    'toad',
+    // 'frog',
+  ],
+  'Grave Hag': [
+    // 'gh',
+  ],
+  Gremist: [],
+  Griffin: [],
+  'Harald the Cripple': [
+    'htc',
+    'harald',
+  ],
+  Harpy: [],
+  'Hawker Healer': [],
+  'Hawker Smuggler': [
+    'smuggler',
+  ],
+  'Hawker Support': [],
+  Henselt: [],
+  Hjalmar: [],
+  'Holger Blackhand': [
+    'holger',
+  ],
+  'Ice Giant': [],
+  'Ida Emean': [
+    'ida',
+  ],
+  Imlerith: [],
+  'Immune Boost': [
+    // 'blizzard',
+  ],
+  'Impenetrable Fog': [
+    'fog',
+  ],
+  'Impera Brigade': [],
+  'Impera Enforcers': [],
+  'Imperial Golem': [
+    'golem',
+  ],
+  Iorveth: [],
+  Iris: [],
+  Isengrim: [],
+  Ithlinne: [],
+  'Joachim De Wett': [
+    'joachim',
+  ],
+  'John Calveit': [
+    'calveit',
+  ],
+  'John Natalis': [
+    'natalis',
+  ],
+  Johnny: [],
+  Jotunn: [],
+  'Jutta an Dimun': [
+    'jutta',
+  ],
+  'Kaedweni Sergeant': [
+    'sergeant',
+    // 'ks',
+  ],
+  'Kaedweni Siege Platform': [
+    'ksp',
+    'siege platform',
+  ],
+  'Kaedweni Siege Support': [
+    'kss',
+    'siege support',
+  ],
+  Kambi: [],
+  Katakan: [],
+  Kayran: [],
+  'Keira Metz': [
+    'keira',
+  ],
+  'King Bran': [
+    'bran',
+  ],
+  'King of Beggars': [
+    'kob',
+  ],
+  Lacerate: [],
+  Lambert: [],
+  'Leo Bonhart': [
+    'leo',
+  ],
+  'Letho of Gulet': [
+    'letho',
+  ],
+  'Light Longship': [
+  ],
+  Lubberkin: [],
+  'Madman Lugos': [],
+  'Mahakam Defender': [
+    'defender',
+    'dorf',
+  ],
+  'Mahakam Guard': [],
+  Malena: [],
+  Mangonel: [],
+  Manticore: [],
+  'Manticore Venom': [],
+  'Marching Orders': [
+    // 'mo',
+  ],
+  Mardroeme: [
+    'mushroom',
+    'shroom',
+  ],
+  'Margarita Laux–Antille': [
+    'margarita',
+    'rita',
+  ],
+  'Menno Coehoorn': [
+    'menno',
+  ],
+  "Merigold's Hailstorm": [
+    'hailstorm',
+    'hail',
+  ],
+  Milva: [],
+  'Monster Nest': [
+    'nest',
+  ],
+  Morenn: [],
+  Morkvarg: [
+    'wolf',
+  ],
+  'Morvran Voorhis': [
+    'morvran',
+  ],
+  Myrgtabrakke: [
+    'myrgta',
+    'brakke',
+  ],
+  "Nature's Gift": [
+    // 'ng',
+  ],
+  'Nauzicaa Brigade': [],
+  'Nauzicaa Standard Bearer': [
+    'nsb',
+    'standard bearer',
+  ],
+  Necromancy: [],
+  Nekker: [],
+  'Nekker Warrior': [
+    // 'nw',
+  ],
+  Nenneke: [],
+  'Nilfgaardian Knight': [
+    // 'nk',
+  ],
+  Nithral: [],
+  Ocvist: [],
+  Odrin: [],
+  'Old Speartip: Asleep': [
+    'speartip',
+  ],
+  Olgierd: [],
+  Operator: [],
+  Overdose: [],
+  Pavetta: [],
+  'Peter Saar Gwynleve': [
+    'psg',
+    'peter',
+  ],
+  'Philippa Eilhart': [
+    'philippa',
+  ],
+  'Priestess of Freya': [
+    'priestess',
+    'freya',
+  ],
+  'Prince Stennis': [
+    'stennis',
+  ],
+  Priscilla: [],
+  'Prize-Winning Cow': [
+    'prize winning cow',
+    'cow',
+  ],
+  Queensguard: [
+    'qg',
+  ],
+  'Quen Sign': [
+    'quen',
+  ],
+  Radovid: [],
+  'Ragh Nar Roog': [
+    'rnr',
+  ],
+  'Raging Berserker': [],
+  Rainfarn: [],
+  'Reaver Hunter': [],
+  'Reaver Scout': [],
+  'Redanian Elite': [],
+  'Redanian Knight': [],
+  'Redanian Knight-Elect': [
+    'rke',
+  ],
+  Regis: [],
+  'Regis: Higher Vampire': [
+    'rhv',
+    'higher vampire',
+  ],
+  'Reinforced Ballista': [
+    'ballista',
+  ],
+  'Reinforced Siege Tower': [
+    'rst',
+    'siege tower',
+  ],
+  'Reinforced Trebuchet': [
+    // 'rt',
+  ],
+  Reinforcement: [],
+  Renew: [],
+  Restore: [
+    'restoration',
+  ],
+  Roach: [],
+  'Rot Tosser': [],
+  'Royal Decree': [
+    'decree',
+  ],
+  'Sabrina Glevissig': [
+    'sabrina',
+  ],
+  Saesenthessis: [],
+  Sarah: [],
+  Saskia: [],
+  'Savage Bear': [
+    'bear',
+  ],
+  Schirru: [],
+  Scorch: [],
+  Serrit: [],
+  Shadow: [],
+  Shani: [],
+  'Sheldon Skaggs': [
+    'sheldon',
+    'skaggs',
+  ],
+  Sigrdrifa: [],
+  'Sile de Tansarville': [
+    'sile',
+  ],
+  'Skellige Storm': [
+    'ss',
+  ],
+  Skjall: [],
+  Spotter: [],
+  "Stammelford's Tremors": [
+    'tremors',
+    'stammelford',
+  ],
+  'Stefan Skellen': [
+    'stefan',
+  ],
+  Succubus: [],
+  'Summoning Circle': [],
+  Svanrige: [],
+  'Swallow Potion': [
+    'swallow',
+  ],
+  Sweers: [],
+  'Temerian Infantryman': [],
+  Thaler: [],
+  'The Guardian': [
+    'guardian',
+  ],
+  'The Last Wish': [
+    'lw',
+    'last wish',
+  ],
+  'Thunderbolt Potion': [
+    'thunderbolt',
+  ],
+  'Tibor Eggebracht': [
+    'tibor',
+  ],
+  'Torrential Rain': [
+    'rain',
+  ],
+  Toruviel: [],
+  Treason: [],
+  Trebuchet: [],
+  'Tridam Infantryman': [
+    'tridam',
+  ],
+  'Triss: Butterfly Spell': [
+    'triss butt',
+  ],
+  'Triss Merigold': [
+    'triss',
+  ],
+  Trollololo: [
+    'trololo',
+  ],
+  Udalryk: [],
+  'Unseen Elder': [
+    'elder',
+  ],
+  Vabjorn: [],
+  Vanhemar: [],
+  'Vattier De Rideaux': [
+    'vdr',
+    'vattier',
+  ],
+  'Vernon Roche': [
+    'vernon',
+    'roche',
+  ],
+  Ves: [],
+  Vesemir: [],
+  'Vicovaro Medic': [],
+  'Vicovaro Novice': [
+    'novice',
+  ],
+  Vilgefortz: [],
+  Villentretenmerth: [
+    'borkh',
+  ],
+  'Vran Warrior': [
+    'vran',
+  ],
+  'Vrihedd Brigade': [],
+  'Vrihedd Dragoon': [
+    'dragoon',
+  ],
+  'Vrihedd Officer': [],
+  'Vrihedd Sappers': [
+    'sapper',
+  ],
+  'Vrihedd Vanguard': [],
+  'War Longship': [
+    'war ship',
+  ],
+  'Water Hag': [],
+  'White Frost': [],
+  'Wild Boar of the Sea': [
+    'wild boar',
+  ],
+  'Wild Hunt Hound': [
+    'hound',
+  ],
+  'Wild Hunt Navigator': [
+    'navigator',
+  ],
+  'Wild Hunt Rider': [
+    'rider',
+    'whr',
+  ],
+  'Wild Hunt Warrior': [
+    'whw',
+  ],
+  'Woodland Spirit': [
+    'leshen',
+  ],
+  Wyvern: [],
+  Xarthisius: [
+    'xarth',
+  ],
+  Yaevinn: [],
+  'Yarpen Zigrin': [
+    'yarpen',
+  ],
+  Yennefer: [
+    'yen',
+  ],
+  'Yennefer: The Conjurer': [
+    'yencon',
+  ],
+  'Zoltan: Animal Tamer': [
+    'zat',
+  ],
+  'Zoltan Chivay': [
+    'chivay',
+  ],
+};
+
+export default ALIASES;

--- a/src/core/data/index.js
+++ b/src/core/data/index.js
@@ -1,7 +1,9 @@
 import CARDS from './CARDS.json';
 import NAMES from './NAMES';
+import ALIASES from './ALIASES';
 
 export {
     CARDS,
     NAMES,
+    ALIASES,
 };

--- a/src/core/dictionary/DICTIONARY.js
+++ b/src/core/dictionary/DICTIONARY.js
@@ -1,24 +1,28 @@
 import pluralize from 'pluralize';
-
+import removeAccents from 'remove-accents';
 import { NAMES, ALIASES } from '../data';
 import create from './create';
 
-const DICTIONARY = create([
-  ...NAMES.map(name => [name.toLowerCase(), name]),
-  // With all plurals
-  ...NAMES.map(name => [pluralize(name.toLowerCase()), name]),
-  // With all pluralized aliases
-  ...NAMES.reduce(
+const DICTIONARY = create(
+  NAMES.reduce(
     (array, name) => {
+      const cleanName = removeAccents(name).toLowerCase();
+
+      // Standard
+      array.push([cleanName, name]);
+      // Plural
+      array.push([pluralize(cleanName), name]);
+
+      // Aliases
       const aliases = ALIASES[name] || [];
       aliases.forEach((alias) => {
-        array.push([alias.toLowerCase(), name]);
-        array.push([pluralize(alias.toLowerCase()), name]);
+        array.push([alias, name]);
+        array.push([pluralize(alias), name]);
       });
       return array;
     },
     [],
   ),
-]);
+);
 
 export default DICTIONARY;

--- a/src/core/dictionary/DICTIONARY.js
+++ b/src/core/dictionary/DICTIONARY.js
@@ -1,12 +1,24 @@
 import pluralize from 'pluralize';
 
-import { NAMES } from '../data';
+import { NAMES, ALIASES } from '../data';
 import create from './create';
 
 const DICTIONARY = create([
   ...NAMES.map(name => [name.toLowerCase(), name]),
   // With all plurals
   ...NAMES.map(name => [pluralize(name.toLowerCase()), name]),
+  // With all pluralized aliases
+  ...NAMES.reduce(
+    (array, name) => {
+      const aliases = ALIASES[name] || [];
+      aliases.forEach((alias) => {
+        array.push([alias.toLowerCase(), name]);
+        array.push([pluralize(alias.toLowerCase()), name]);
+      });
+      return array;
+    },
+    [],
+  ),
 ]);
 
 export default DICTIONARY;

--- a/src/core/dictionary/__tests__/index.js
+++ b/src/core/dictionary/__tests__/index.js
@@ -1,4 +1,5 @@
 import test from 'ava';
+import removeAccents from 'remove-accents';
 import DICTIONARY, { contains, matches } from '../';
 import { NAMES } from '../../data';
 
@@ -8,7 +9,8 @@ test('Dictionary was created successfully', (t) => {
 
 test('Dictionary contains all cards', (t) => {
   NAMES.forEach((name) => {
-    const exists = contains(DICTIONARY, name.toLowerCase());
+    const exists = contains(DICTIONARY, removeAccents(name).toLowerCase());
+
     t.truthy(exists);
   });
 });

--- a/src/core/findAllMatches.js
+++ b/src/core/findAllMatches.js
@@ -1,3 +1,4 @@
+import removeAccents from 'remove-accents';
 import { matches } from './dictionary';
 
 /*
@@ -17,15 +18,15 @@ type Match = {
  * @return {Array<Match>} The ranges of matched text.
  */
 function findAllMatches(dictionary, text) {
-  const lowcaseText = text.toLowerCase();
+  const cleanText = removeAccents(text).toLowerCase();
   const result = [];
 
   // Only match at beginning of words
   let wasNotWord = true;
-  for (let i = 0; i < lowcaseText.length; i += 1) {
-    const isWord = /\w/.test(lowcaseText[i]);
+  for (let i = 0; i < cleanText.length; i += 1) {
+    const isWord = /\w/.test(cleanText[i]);
     if (wasNotWord && isWord) {
-      const match = matches(dictionary, lowcaseText, i);
+      const match = matches(dictionary, cleanText, i);
       if (match) {
         result.push(match);
 
@@ -34,7 +35,7 @@ function findAllMatches(dictionary, text) {
       }
     }
 
-    wasNotWord = /[^\w]/.test(lowcaseText[i]);
+    wasNotWord = /[^\w]/.test(cleanText[i]);
   }
 
   return result;

--- a/yarn.lock
+++ b/yarn.lock
@@ -4479,6 +4479,10 @@ relateurl@0.2.x:
   version "0.2.7"
   resolved "https://registry.yarnpkg.com/relateurl/-/relateurl-0.2.7.tgz#54dbf377e51440aca90a4cd274600d3ff2d888a9"
 
+remove-accents@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/remove-accents/-/remove-accents-0.4.0.tgz#5e3ceab210220cc334718e77fa1f07d6740f7a37"
+
 renderkid@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/renderkid/-/renderkid-2.0.1.tgz#898cabfc8bede4b7b91135a3ffd323e58c0db319"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4479,9 +4479,9 @@ relateurl@0.2.x:
   version "0.2.7"
   resolved "https://registry.yarnpkg.com/relateurl/-/relateurl-0.2.7.tgz#54dbf377e51440aca90a4cd274600d3ff2d888a9"
 
-remove-accents@^0.4.0:
+remove-accents@tyxla/remove-accents#8025d6cd35900226f6c1d4dd709ad653fb74357b:
   version "0.4.0"
-  resolved "https://registry.yarnpkg.com/remove-accents/-/remove-accents-0.4.0.tgz#5e3ceab210220cc334718e77fa1f07d6740f7a37"
+  resolved "https://codeload.github.com/tyxla/remove-accents/tar.gz/8025d6cd35900226f6c1d4dd709ad653fb74357b"
 
 renderkid@^2.0.1:
   version "2.0.1"


### PR DESCRIPTION
I used and adapted https://github.com/PabloSzx/Gwent-Cards/blob/master/src/data/nicknames.json

@PabloSzx is it all right?

My modification includes:

- Excluding most 2 characters aliases
- Adding a few more

There are still issues with accentuated letters. We should support them. Note also that they are normalized in the aliases map. So some aliases like Schirrú are not working yet.