### PR TITLE
Fix tooltip position when not enough room to the right

### DIFF
--- a/src/core/tooltip/tooltip.js
+++ b/src/core/tooltip/tooltip.js
@@ -94,12 +94,10 @@ class CardTooltip {
     const { innerWidth, innerHeight } = window;
     const tooltipRect = tooltip.getBoundingClientRect();
 
-    let left;
+    let left = clientX;
     if (left > innerWidth - tooltipRect.width) {
       // Too far on the right
       left = clientX - tooltipRect.width;
-    } else {
-      left = clientX;
     }
 
     let top = clientY;


### PR DESCRIPTION
The tooltip wasn't positioned to the left when there was not enough space to the right.