### PR TITLE
Fix demo website

### DIFF
--- a/src/extension/walk.js
+++ b/src/extension/walk.js
@@ -13,9 +13,7 @@ const GWENTDB_TOOLTIP_ATTR = 'data-tooltip-url';
 const GWENTDB_HOSTNAME = 'www.gwentdb.com';
 
 // Walk the document and highlight cards
-function walk(options) {
-  const { shouldUnderline = true } = options;
-
+function walk({ shouldUnderline = true } = {}) {
   const HOSTNAME = urlParse(window.location.href).hostname;
 
   const walker = window.document.createTreeWalker(


### PR DESCRIPTION
`walk()` expects options to always be provided but it's missing in the demo and thus it's broken 😱 