### PR TITLE
Lazy load card images

### DIFF
--- a/core/tooltip/TooltipElement.js
+++ b/core/tooltip/TooltipElement.js
@@ -47,14 +47,15 @@ function CardArtImage({ art }: { art: CardArt }): HTMLElement {
  */
 function loadTooltipArt(tooltipWrapper: HTMLElement) {
     const cardArtImage = tooltipWrapper.querySelector('[data-art-src]');
-    console.log({ cardArtImage });
     if (!cardArtImage) return;
 
     const artSrc: ?string = cardArtImage.getAttribute('data-art-src');
-    console.log({ artSrc });
     if (!artSrc) return;
 
+    if (cardArtImage.getAttribute('data-art-loaded')) return;
+
     cardArtImage.setAttribute('style', `background-image: url(${artSrc})`);
+    cardArtImage.setAttribute('data-art-loaded', 'true');
 }
 
 function TooltipHeader({

--- a/core/tooltip/TooltipElement.js
+++ b/core/tooltip/TooltipElement.js
@@ -13,14 +13,16 @@ const styles = TooltipCSS.locals;
 
 function TooltipElement({
     card,
-    assets
+    assets,
+    lowQualityArt
 }: {
     card: Card,
-    assets: ExtensionAssets
+    assets: ExtensionAssets,
+    lowQualityArt: boolean
 }): HTMLElement {
     return (
         <div className={styles.card}>
-            <CardArtImage art={card.art} />
+            <CardArtImage art={card.art} lowQualityArt={lowQualityArt} />
             <div className={styles.tooltip}>
                 <TooltipHeader
                     faction={card.faction}
@@ -33,10 +35,18 @@ function TooltipElement({
     );
 }
 
-function CardArtImage({ art }: { art: CardArt }): HTMLElement {
+function CardArtImage({
+    art,
+    lowQualityArt
+}: {
+    art: CardArt,
+    lowQualityArt: boolean
+}): HTMLElement {
+    const src = lowQualityArt ? art.thumbnail : art.low;
+
     return (
         <div className={styles.artFrame}>
-            <div className={styles.art} data-art-src={art.low} />
+            <div className={styles.art} data-art-src={src} />
         </div>
     );
 }

--- a/core/tooltip/TooltipElement.js
+++ b/core/tooltip/TooltipElement.js
@@ -36,14 +36,25 @@ function TooltipElement({
 function CardArtImage({ art }: { art: CardArt }): HTMLElement {
     return (
         <div className={styles.artFrame}>
-            <div
-                className={styles.art}
-                style={{
-                    backgroundImage: `url(${art.low})`
-                }}
-            />
+            <div className={styles.art} data-art-src={art.low} />
         </div>
     );
+}
+
+/*
+ * Tooltip's art is not loaded until shown. Call this on the tooltip
+ * before showing it to ensure the card art is loaded.
+ */
+function loadTooltipArt(tooltipWrapper: HTMLElement) {
+    const cardArtImage = tooltipWrapper.querySelector('[data-art-src]');
+    console.log({ cardArtImage });
+    if (!cardArtImage) return;
+
+    const artSrc: ?string = cardArtImage.getAttribute('data-art-src');
+    console.log({ artSrc });
+    if (!artSrc) return;
+
+    cardArtImage.setAttribute('style', `background-image: url(${artSrc})`);
 }
 
 function TooltipHeader({
@@ -128,3 +139,4 @@ function tagKeywords(text): Array<string | HTMLElement> {
 }
 
 export default TooltipElement;
+export { loadTooltipArt };

--- a/core/tooltip/attachTooltip.js
+++ b/core/tooltip/attachTooltip.js
@@ -29,11 +29,24 @@ class CardTooltip {
 
     assets: ExtensionAssets;
 
-    constructor(card: Card, anchor: HTMLElement, assets: ExtensionAssets) {
+    constructor(
+        card: Card,
+        anchor: HTMLElement,
+        assets: ExtensionAssets,
+        options: {
+            lowQualityArt: boolean
+        }
+    ) {
         this.assets = assets;
         this.anchor = anchor;
 
-        const tooltip = <TooltipElement card={card} assets={assets} />;
+        const tooltip = (
+            <TooltipElement
+                card={card}
+                assets={assets}
+                lowQualityArt={options.lowQualityArt}
+            />
+        );
         const wrapper = (
             <div
                 className={styles.wrapperHidden}
@@ -143,9 +156,10 @@ function autoSizeCardName(tooltipElement) {
 function attachTooltip(
     card: Card,
     anchor: HTMLElement,
-    assets: ExtensionAssets
+    assets: ExtensionAssets,
+    options: { lowQualityArt: boolean }
 ) {
-    const tooltip = new CardTooltip(card, anchor, assets);
+    const tooltip = new CardTooltip(card, anchor, assets, options);
     tooltip.inject();
 }
 

--- a/core/tooltip/attachTooltip.js
+++ b/core/tooltip/attachTooltip.js
@@ -8,7 +8,7 @@ import BigText from 'big-text.js';
 
 import type { Card, ExtensionAssets } from '../types';
 import TooltipCSS from './tooltip.less';
-import TooltipElement from './TooltipElement';
+import TooltipElement, { loadTooltipArt } from './TooltipElement';
 import injectStyles from './injectStyles';
 
 const styles = TooltipCSS.locals;
@@ -18,7 +18,7 @@ class CardTooltip {
     visible = false;
 
     // Tooltipped element
-    target = <span />;
+    anchor = <span />;
 
     // Outer element used to scope CSS
     outer = <div />;
@@ -28,9 +28,9 @@ class CardTooltip {
 
     assets: ExtensionAssets;
 
-    constructor(card: Card, target: HTMLElement, assets: ExtensionAssets) {
+    constructor(card: Card, anchor: HTMLElement, assets: ExtensionAssets) {
         this.assets = assets;
-        this.target = target;
+        this.anchor = anchor;
 
         const tooltip = <TooltipElement card={card} assets={assets} />;
         const wrapper = (
@@ -58,15 +58,15 @@ class CardTooltip {
 
     // Inject this tooltip in the page
     inject() {
-        const { outer, target } = this;
+        const { outer, anchor } = this;
 
         window.document.body.appendChild(outer);
 
         injectStyles(this.assets);
 
-        target.addEventListener('mouseenter', () => this.show());
-        target.addEventListener('mouseleave', () => this.hide());
-        target.addEventListener('mousemove', (e: MouseEvent) => this.follow(e));
+        anchor.addEventListener('mouseenter', () => this.show());
+        anchor.addEventListener('mouseleave', () => this.hide());
+        anchor.addEventListener('mousemove', (e: MouseEvent) => this.follow(e));
     }
 
     hide() {
@@ -76,12 +76,7 @@ class CardTooltip {
 
     show() {
         const { wrapper } = this;
-
-        const img = wrapper.querySelector('[data-src]');
-        if (img) {
-            img.setAttribute('src', img.getAttribute('data-src'));
-            img.removeAttribute('data-src');
-        }
+        loadTooltipArt(wrapper);
 
         wrapper.className = styles.wrapperVisible;
 
@@ -137,10 +132,10 @@ function autoSizeCardName(tooltipElement) {
 
 function attachTooltip(
     card: Card,
-    target: HTMLElement,
+    anchor: HTMLElement,
     assets: ExtensionAssets
 ) {
-    const tooltip = new CardTooltip(card, target, assets);
+    const tooltip = new CardTooltip(card, anchor, assets);
     tooltip.inject();
 }
 

--- a/core/tooltip/attachTooltip.js
+++ b/core/tooltip/attachTooltip.js
@@ -1,9 +1,10 @@
 // @flow
 /* @jsx createElement */
-/* global window */
+/* global window Perimeter */
 
 // eslint-disable-next-line no-unused-vars
 import { createElement } from 'jsx-dom';
+import 'perimeter/dist/perimeter';
 import BigText from 'big-text.js';
 
 import type { Card, ExtensionAssets } from '../types';
@@ -58,11 +59,20 @@ class CardTooltip {
 
     // Inject this tooltip in the page
     inject() {
-        const { outer, anchor } = this;
+        const { outer, anchor, wrapper } = this;
 
         window.document.body.appendChild(outer);
 
         injectStyles(this.assets);
+
+        Perimeter({
+            target: anchor,
+            outline: 100,
+            debug: true,
+            onBreach() {
+                loadTooltipArt(wrapper);
+            }
+        });
 
         anchor.addEventListener('mouseenter', () => this.show());
         anchor.addEventListener('mouseleave', () => this.hide());

--- a/core/walk.js
+++ b/core/walk.js
@@ -23,7 +23,10 @@ function walk(
         },
         dictionary: Dictionary<CardID>
     },
-    { shouldUnderline = true }: { shouldUnderline?: boolean } = {}
+    {
+        shouldUnderline = true,
+        lowQualityArt = false
+    }: { shouldUnderline?: boolean, lowQualityArt?: boolean } = {}
 ) {
     const nodesToInspect = findNodesToInspect();
 
@@ -58,7 +61,7 @@ function walk(
         const cardId: CardID = (highlight.getAttribute(CARD_ID_ATTRIBUTE): any);
         const card = cards[cardId];
 
-        attachTooltip(card, highlight, assets);
+        attachTooltip(card, highlight, assets, { lowQualityArt });
     }
 }
 

--- a/extension/content.js
+++ b/extension/content.js
@@ -29,9 +29,11 @@ const DICTIONARY_SRC = `${WEBSITE}/dictionary.json`;
 
 async function init() {
     const options: {
-        shouldUnderline?: boolean
+        shouldUnderline?: boolean,
+        lowQualityArt?: boolean
     } = await browser.storage.sync.get({
-        shouldUnderline: true
+        shouldUnderline: true,
+        lowQualityArt: false
     });
 
     const { cards, dictionary } = await retrieveCardsData({

--- a/extension/options.html
+++ b/extension/options.html
@@ -1,49 +1,46 @@
 <!DOCTYPE html>
 <html>
-<head>
-  <title>Hyper Gwent Options</title>
-  <style>
-  body {
-    padding: 10px;
-  }
+  <head>
+    <title>Hyper Gwent Options</title>
+    <style>
+      body {
+        padding: 10px;
+      }
 
-  label {
-    display: block;
-    margin: 10px;
-  }
+      label {
+        display: block;
+        margin: 10px;
+      }
 
-  button {
-    display: block;
-    margin: 10px;
-  }
+      button {
+        display: block;
+        margin: 10px;
+      }
 
-  #status {
-  }
+      .hidden {
+        opacity: 0;
+        transition: all 0.5s;
+      }
 
-  .hidden {
-    opacity: 0;
-    transition: all 0.5s;
-  }
+      .visible {
+        opacity: 1;
+      }
+    </style>
+  </head>
 
-  .visible {
-    opacity: 1;
-  }
+  <body>
+    <label>
+      <input type="checkbox" id="underline" /> Underline card names
+    </label>
 
-  </style>
-</head>
+    <label>
+      <input type="checkbox" id="low-quality" /> Use low quality card arts. This helps display tooltips faster if you internet connection is slow.
+    </label>
 
-<body>
-  <label>
-    <input type="checkbox" id="underline">
-    Underline card names
-  </label>
+    <label id="status" class="hidden"> Saved </label>
 
-  <label id="status" class="hidden">
-    Saved
-  </label>
+    <button id="save">Save</button>
 
-  <button id="save">Save</button>
-
-  <script src="options.js"></script>
-</body>
+    <script src="options.js"></script>
+  </body>
 </html>

--- a/extension/options.html
+++ b/extension/options.html
@@ -4,12 +4,13 @@
     <title>Hyper Gwent Options</title>
     <style>
       body {
-        padding: 10px;
+        padding: 20px;
       }
 
       label {
         display: block;
-        margin: 10px;
+        margin-bottom: 30px;
+        margin-top: 30px;
       }
 
       button {
@@ -25,6 +26,11 @@
       .visible {
         opacity: 1;
       }
+
+      .hint {
+        margin-top: 10px;
+        color: #777
+      }
     </style>
   </head>
 
@@ -34,8 +40,12 @@
     </label>
 
     <label>
-      <input type="checkbox" id="low-quality" /> Use low quality card arts. This helps display tooltips faster if you internet connection is slow.
+      <input type="checkbox" id="low-quality" /> Use low quality card arts.
+      <div class="hint">
+        This helps display tooltips faster if you internet connection is slow.
+      </div>
     </label>
+
 
     <label id="status" class="hidden"> Saved </label>
 

--- a/extension/options.js
+++ b/extension/options.js
@@ -5,7 +5,7 @@ import browser from 'webextension-polyfill';
 
 // Access to settings UI elements
 const UI = {
-    get save(): HTMLButtonElement {
+    get saveButton(): HTMLButtonElement {
         // $FlowFixMe
         return document.getElementById('save');
     },
@@ -15,6 +15,11 @@ const UI = {
         return document.getElementById('underline');
     },
 
+    get lowQualityArt(): HTMLInputElement {
+        // $FlowFixMe
+        return document.getElementById('low-quality');
+    },
+
     get status(): HTMLElement {
         // $FlowFixMe
         return document.getElementById('status');
@@ -22,21 +27,21 @@ const UI = {
 };
 
 // Saves options to browser.storage.sync.
-function saveOptions() {
+async function saveOptions() {
     const shouldUnderline = UI.shouldUnderline.checked;
+    const lowQualityArt = UI.lowQualityArt.checked;
 
-    browser.storage.sync
-        .set({
-            shouldUnderline
-        })
-        .then(() => {
-            // Update status to let user know options were saved.
+    await browser.storage.sync.set({
+        shouldUnderline,
+        lowQualityArt
+    });
 
-            UI.status.setAttribute('class', 'visible');
-            setTimeout(() => {
-                UI.status.setAttribute('class', 'hidden');
-            }, 1000);
-        });
+    // Update status to let user know options were saved.
+    UI.status.setAttribute('class', 'visible');
+
+    setTimeout(() => {
+        UI.status.setAttribute('class', 'hidden');
+    }, 1000);
 }
 
 // Restores select box and checkbox state using the preferences
@@ -45,12 +50,14 @@ function restoreOptions() {
     // Use default value color = 'red' and likesColor = true.
     browser.storage.sync
         .get({
-            shouldUnderline: true
+            shouldUnderline: true,
+            lowQualityArt: false
         })
         .then(items => {
             UI.shouldUnderline.checked = items.shouldUnderline;
+            UI.lowQualityArt.checked = items.lowQualityArt;
         });
 }
 
 document.addEventListener('DOMContentLoaded', restoreOptions);
-UI.save.addEventListener('click', saveOptions);
+UI.saveButton.addEventListener('click', saveOptions);

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "gwent-data-release": "GwentCommunityDevelopers/gwent-data-release#039f508ee2dabe5d108dba91310a849de3185b99",
     "intercalate": "^0.1.2",
     "jsx-dom": "^6.2.1",
+    "perimeter": "e-sites/perimeter.js#cec3714abfa8e3c25c318775773c3ed16bbe3793",
     "pluralize": "^6.0.0",
     "remove-accents": "^0.4.1",
     "seamless-immutable": "^7.1.2",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "gwent-data-release": "GwentCommunityDevelopers/gwent-data-release#039f508ee2dabe5d108dba91310a849de3185b99",
     "intercalate": "^0.1.2",
     "jsx-dom": "^6.2.1",
-    "perimeter": "e-sites/perimeter.js#cec3714abfa8e3c25c318775773c3ed16bbe3793",
+    "perimeter": "Soreine/perimeter.js#57381b3e6bb0a82a4d48bbe4ccb7b215276aa974",
     "pluralize": "^6.0.0",
     "remove-accents": "^0.4.1",
     "seamless-immutable": "^7.1.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5241,6 +5241,10 @@ performance-now@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/performance-now/-/performance-now-2.1.0.tgz#6309f4e0e5fa913ec1c69307ae364b4b377c9e7b"
 
+perimeter@e-sites/perimeter.js#cec3714abfa8e3c25c318775773c3ed16bbe3793:
+  version "0.3.0"
+  resolved "https://codeload.github.com/e-sites/perimeter.js/tar.gz/cec3714abfa8e3c25c318775773c3ed16bbe3793"
+
 pify@^2.0.0, pify@^2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/pify/-/pify-2.3.0.tgz#ed141a6ac043a849ea588498e7dca8b15330e90c"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5241,9 +5241,9 @@ performance-now@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/performance-now/-/performance-now-2.1.0.tgz#6309f4e0e5fa913ec1c69307ae364b4b377c9e7b"
 
-perimeter@e-sites/perimeter.js#cec3714abfa8e3c25c318775773c3ed16bbe3793:
+perimeter@Soreine/perimeter.js#57381b3e6bb0a82a4d48bbe4ccb7b215276aa974:
   version "0.3.0"
-  resolved "https://codeload.github.com/e-sites/perimeter.js/tar.gz/cec3714abfa8e3c25c318775773c3ed16bbe3793"
+  resolved "https://codeload.github.com/Soreine/perimeter.js/tar.gz/57381b3e6bb0a82a4d48bbe4ccb7b215276aa974"
 
 pify@^2.0.0, pify@^2.3.0:
   version "2.3.0"


### PR DESCRIPTION
The card images will be loaded only when the tooltip is displayed (it broke what was made in https://github.com/Soreine/hyper-gwent/pull/28)
As an optimization, the card images will be preloaded when the mouse approach a card's name.