### PR TITLE
Cleanup tooltips when card names are removed

### DIFF
--- a/core/tooltip/Perimeter.js
+++ b/core/tooltip/Perimeter.js
@@ -146,6 +146,7 @@ Perimeter.prototype.recalculate = function recalculate() {
         }
     } else {
         i = instances.length;
+        // eslint-disable-next-line
         while (i--) {
             inst = instances[i];
             inst.rects = inst.getClientRect(inst.target);
@@ -168,7 +169,10 @@ Perimeter.prototype.trigger = function trigger(event) {
         leave: this.options.onLeave
     };
 
-    if (events.hasOwnProperty(event) && events[event] instanceof Function) {
+    if (
+        Object.prototype.hasOwnProperty.call(events, event) &&
+        events[event] instanceof Function
+    ) {
         events[event].apply(this, []);
     }
 };
@@ -187,12 +191,12 @@ Perimeter.prototype.formatOutline = function formatOutline(outline) {
     let i = 0;
 
     while (i < 4) {
-        if (!isNaN(outline)) {
+        if (!Number.isNaN(outline)) {
             arr.push(parseInt(outline, 10));
         } else {
             arr.push(!outline[i] ? 0 : parseInt(outline[i], 10));
         }
-        i++;
+        i += 1;
     }
 
     return arr;

--- a/core/tooltip/Perimeter.js
+++ b/core/tooltip/Perimeter.js
@@ -1,0 +1,394 @@
+/* global window */
+
+// Implementation based on https://github.com/e-sites/perimeter.js
+
+/*
+ *  Project: Perimeter.js
+ *  Creates an invisible perimeter around a target element and monitors mouse breaches.
+ *  When a breach is detected the corresponding callback will be invoked.
+ *  This gives the opportunity to e.g. lazy-load scripts, show a tooltip or whatnot.
+ *
+ *  @author  : Boye Oomens <github@e-sites.nl>
+ *  @version : 0.3.0
+ *  @license : MIT
+ *  @see     : http://github.e-sites.nl/perimeter.js/
+ */
+
+const win = window;
+
+const doc = window.document;
+
+const docElem = doc.documentElement;
+
+const docBody = doc.body;
+
+const instances = [];
+
+function addEventListener(obj, evt, fn) {
+    obj.addEventListener(evt, fn, false);
+}
+
+function removeEventListener(obj, evt, fn) {
+    obj.removeEventListener(evt, fn, false);
+}
+
+/**
+ * Global Perimeter constructor
+ *
+ */
+function Perimeter(options) {
+    // We need at least a target element and an outline to work with
+    if (!options || !options.target || !options.outline) {
+        throw new Error('Missing target');
+    }
+
+    /**
+     * Perimeter options
+     */
+    this.options = options;
+
+    /**
+     * The amount of perimeter breaches
+     */
+    this.breaches = [];
+
+    /**
+     * Whether the perimeter has been breached
+     */
+    this.alarm = false;
+
+    /**
+     * Outline around the target element
+     * This can either be an array with top/right/bottom/left dimensions
+     * or just one number which acts as shorthand for all directions
+     *
+     * @type {Number|Array}
+     */
+    this.outline = this.formatOutline(options.outline);
+
+    /**
+     * Target element
+     */
+    this.target =
+        typeof options.target === 'string'
+            ? doc.getElementById(options.target)
+            : options.target;
+
+    /**
+     * Boundary used for debugging purposes
+     */
+    this.boundary = null;
+
+    /**
+     * Bounding rectangles
+     *
+     * @type {Object} ClientRect
+     */
+    this.rects = this.getClientRect(this.target);
+
+    /**
+     * Breach monitor
+     * @type {Monitor}
+     */
+    this.monitor = new this.Monitor(this);
+
+    this.init(options);
+}
+
+/**
+ * Small helper to fetch cross-browser scroll values
+ *
+ * @return {Object} top and left scroll pos
+ */
+Perimeter.prototype.getScrollPos = function getScrollPos() {
+    return {
+        top: docElem.scrollTop || docBody.scrollTop,
+        left: docElem.scrollLeft || docBody.scrollLeft
+    };
+};
+
+/**
+ * Returns the given element dimensions and offset
+ * based on getBoundingClientRect including document scroll offset
+ *
+ * @param {HTMLElement} elem target element
+ * @return {Object}
+ */
+Perimeter.prototype.getClientRect = function getClientRect(elem) {
+    const scrollPos = this.getScrollPos();
+
+    if (typeof elem.getBoundingClientRect === 'undefined') {
+        throw new Error(
+            'Perimeter.js detected that your browser does not support getBoundingClientRect'
+        );
+    }
+
+    const box = elem.getBoundingClientRect();
+
+    return {
+        width: box.width || elem.offsetWidth,
+        height: box.height || elem.offsetHeight,
+        top: box.top + scrollPos.top - docElem.clientTop,
+        left: box.left + scrollPos.left - docElem.clientLeft
+    };
+};
+
+/**
+ * When triggered via onresize it will recalculate the clientRect and reflow all existing boundaries
+ */
+Perimeter.prototype.recalculate = function recalculate() {
+    let inst;
+    let i;
+    if (this instanceof Perimeter) {
+        this.outline = this.formatOutline(this.outline);
+        if (this.options.debug && this.boundary) {
+            this.boundary.reflow();
+        }
+    } else {
+        i = instances.length;
+        while (i--) {
+            inst = instances[i];
+            inst.rects = inst.getClientRect(inst.target);
+            if (inst.options.debug && inst.boundary) {
+                inst.boundary.reflow();
+            }
+        }
+    }
+};
+
+/**
+ * Triggers the corresponding callback of the given event type
+ *
+ * @param {String} event event type
+ * @return {Boolean}
+ */
+Perimeter.prototype.trigger = function trigger(event) {
+    const events = {
+        breach: this.options.onBreach,
+        leave: this.options.onLeave
+    };
+
+    if (events.hasOwnProperty(event) && events[event] instanceof Function) {
+        events[event].apply(this, []);
+    }
+};
+
+/**
+ * Formats the given outline, this can either be a number or an array with numbers
+ * When the numbers are passed as string they will be converted to numbers
+ * Also,
+ *
+ * @param  {Array|Number} outline
+ * @return {Array}
+ */
+Perimeter.prototype.formatOutline = function formatOutline(outline) {
+    const arr = [];
+
+    let i = 0;
+
+    while (i < 4) {
+        if (!isNaN(outline)) {
+            arr.push(parseInt(outline, 10));
+        } else {
+            arr.push(!outline[i] ? 0 : parseInt(outline[i], 10));
+        }
+        i++;
+    }
+
+    return arr;
+};
+
+/**
+ * Main init method that kickstarts everything
+ */
+Perimeter.prototype.init = function init(options) {
+    // Cancel the process when the target DOM element is not present
+    if (!this.target) {
+        return;
+    }
+
+    // Keep track of all instances
+    instances.push(this);
+
+    // Create and show boundary when debug option is passed
+    if (options.debug && typeof this.Boundary !== 'undefined') {
+        this.boundary = new this.Boundary(this);
+    }
+
+    addEventListener(options.monitor || doc, 'mousemove', this.monitor.observe);
+    addEventListener(win, 'resize', this.recalculate);
+
+    // Due to different browser behavior when it comes to triggering the mousemove event
+    // while scrolling using the mousehweel, we need to listen to this event as well
+    addEventListener(doc, 'DOMMouseScroll', this.monitor.observe);
+    addEventListener(doc, 'mousewheel', this.monitor.observe);
+
+    // teardown
+    this.destroy = () => {
+        removeEventListener(
+            options.monitor || doc,
+            'mousemove',
+            this.monitor.observe
+        );
+        removeEventListener(win, 'resize', this.recalculate);
+        removeEventListener(doc, 'DOMMouseScroll', this.monitor.observe);
+        removeEventListener(doc, 'mousewheel', this.monitor.observe);
+    };
+};
+
+Perimeter.prototype.Monitor = function Monitor(perimeter) {
+    const monitor = this;
+
+    /**
+     * Reference to the event object
+     *
+     * @type {Object}
+     */
+    this.event = null;
+
+    /**
+     * Detects a breach and when the cursor leaves the perimeter
+     *
+     * @param {String} state either breach or leave
+     */
+    this.detect = function detect(state) {
+        const { outline } = perimeter;
+
+        const posX = this.event.clientX;
+
+        const posY = this.event.clientY;
+
+        const scrollPos = perimeter.getScrollPos();
+
+        const maxTop = parseInt(
+            perimeter.rects.top - scrollPos.top - outline[0],
+            10
+        );
+
+        const maxLeft = parseInt(
+            perimeter.rects.left - scrollPos.left - outline[3],
+            10
+        );
+
+        switch (state) {
+            case 'breach':
+                if (
+                    posY >= maxTop &&
+                    posY <
+                        maxTop +
+                            perimeter.rects.height +
+                            (outline[0] + outline[2]) &&
+                    posX >= maxLeft &&
+                    posX <
+                        maxLeft +
+                            perimeter.rects.width +
+                            (outline[1] + outline[3])
+                ) {
+                    perimeter.breaches.push([posX, posY]);
+                    perimeter.trigger('breach');
+                    perimeter.alarm = true;
+                }
+                break;
+            case 'leave':
+                if (
+                    posY < maxTop ||
+                    posY >
+                        maxTop +
+                            perimeter.rects.height +
+                            (outline[0] + outline[2]) ||
+                    posX < maxLeft ||
+                    posX >
+                        maxLeft +
+                            perimeter.rects.width +
+                            (outline[1] + outline[3])
+                ) {
+                    perimeter.trigger('leave');
+                    perimeter.alarm = false;
+                }
+                break;
+            default:
+                break;
+        }
+    };
+
+    /**
+     * Main observer that invokes the detection
+     *
+     * @param {Object} e Event object
+     */
+    this.observe = function observe(e) {
+        monitor.event = e || window.event;
+        perimeter.monitor.detect(perimeter.alarm ? 'leave' : 'breach');
+    };
+
+    return this.event;
+};
+
+Perimeter.prototype.Boundary = function Boundary(perimeter) {
+    /**
+     * Boundary division element
+     *
+     * @type {HTMLDivElement}
+     */
+    this.elem = null;
+
+    /**
+     * Recalculates rectangle offset and dimensions based on new outline
+     *
+     * @return {Object} newRect
+     * @private
+     */
+    function recalculateRect(target, outline) {
+        const rects = perimeter.rects || perimeter.getClientRect(target);
+
+        const newRect = {};
+
+        newRect.width = rects.width + (outline[1] + outline[3]);
+        newRect.height = rects.height + (outline[0] + outline[2]);
+        newRect.top = rects.top - outline[0];
+        newRect.left = rects.left - outline[3];
+
+        return newRect;
+    }
+
+    /**
+     * Creates the division and injects it into the DOM
+     *
+     * @return {Object}
+     */
+    this.create = function create() {
+        this.elem = doc.createElement('div');
+        this.elem.className = 'boundary';
+
+        this.reflow(perimeter.target, perimeter.outline);
+
+        doc.body.appendChild(this.elem);
+
+        return this;
+    };
+
+    /**
+     * Repositions the boundary element
+     *
+     * @param  {Object} target
+     * @param  {Number} outline
+     * @return {Object}
+     */
+    this.reflow = function reflow(target, pOutline) {
+        const box = target || perimeter.target;
+
+        const outline = perimeter.formatOutline(pOutline || perimeter.outline);
+        const rect = recalculateRect(box, outline);
+
+        this.elem.style.top = `${rect.top}px`;
+        this.elem.style.left = `${rect.left}px`;
+        this.elem.style.width = `${rect.width}px`;
+        this.elem.style.height = `${rect.height}px`;
+
+        return this;
+    };
+
+    return this.create();
+};
+
+export default Perimeter;

--- a/core/tooltip/attachTooltip.js
+++ b/core/tooltip/attachTooltip.js
@@ -1,6 +1,6 @@
 // @flow
 /* @jsx createElement */
-/* global window */
+/* global window, MutationObserver */
 
 // eslint-disable-next-line no-unused-vars
 import { createElement } from 'jsx-dom';
@@ -172,9 +172,11 @@ function onRemoveElement(element, onDetachCallback) {
     // https://stackoverflow.com/questions/31798816/simple-mutationobserver-version-of-domnoderemovedfromdocument
     const observer = new MutationObserver(() => {
         function isDetached(el) {
+            // $FlowFixMe
             if (el.parentNode === window.document) {
                 return false;
             }
+            // $FlowFixMe
             if (el.parentNode === null) {
                 return true;
             }

--- a/core/walk.js
+++ b/core/walk.js
@@ -1,6 +1,6 @@
 // @flow
 /* @jsx createElement */
-/* global document */
+/* global document, window */
 
 // eslint-disable-next-line no-unused-vars
 import { createElement } from 'jsx-dom';
@@ -9,7 +9,7 @@ import splitAndMapMatches from './splitAndMapMatches';
 import { attachTooltip } from './tooltip';
 import createWalker from './createWalker';
 import type { ExtensionAssets, Card, Dictionary } from './types';
-import { shouldIgnore } from './acceptNode';
+import { shouldIgnore, acceptNode } from './acceptNode';
 
 import { HG_HIGHLIGHT_ATTRIBUTE, CARD_ID_ATTRIBUTE } from './CONSTANTS';
 
@@ -85,12 +85,18 @@ function findTextNodesToInspect(target: Node): Node[] {
         return [];
     }
 
-    const nodes = [];
     const walker = createWalker(target);
-    while (walker.nextNode()) {
-        const node = walker.currentNode;
-        nodes.push(node);
+    const nodes = [];
+
+    // Include targets itself, to handle walking text nodes
+    if (acceptNode(walker.currentNode) === window.NodeFilter.FILTER_ACCEPT) {
+        nodes.push(walker.currentNode);
     }
+
+    while (walker.nextNode()) {
+        nodes.push(walker.currentNode);
+    }
+
     return nodes;
 }
 

--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
     "gwent-data-release": "https://github.com/GwentCommunityDevelopers/gwent-data-release/tarball/286603f7cf34dd04bafabf8fafe7e62cc6829c83/gwent-data-release.tar.gz",
     "intercalate": "^0.1.2",
     "jsx-dom": "^6.2.1",
-    "perimeter": "https://github.com/Soreine/perimeter.js/tarball/57381b3e6bb0a82a4d48bbe4ccb7b215276aa974/perimeter.js.tar.gz",
     "pluralize": "^6.0.0",
     "preact": "^8.4.2",
     "remove-accents": "^0.4.1",

--- a/website/RandomCard.js
+++ b/website/RandomCard.js
@@ -8,8 +8,9 @@ import {
     render,
     Component
 } from 'preact';
+import type { Card } from '../core/types';
 
-const CHANGE_CARD_DELAY = 1000; // ms
+const CHANGE_CARD_DELAY = 3000; // ms
 
 function getRandomCard(cards: { [CardID]: Card }): Card {
     const ids = Object.keys(cards);
@@ -40,7 +41,6 @@ class RandomCard extends Component<
 
     componentDidMount() {
         this.interval = setInterval(this.changeCard, CHANGE_CARD_DELAY);
-        // this.interval = setTimeout(this.changeCard, CHANGE_CARD_DELAY * 2);
     }
 
     componentWillUnmount() {
@@ -59,7 +59,8 @@ class RandomCard extends Component<
         const { card } = this.state;
         return (
             <div>
-                {card.name} <br />
+                {card.name}
+                <br />
             </div>
         );
     }

--- a/website/RandomCard.js
+++ b/website/RandomCard.js
@@ -1,0 +1,75 @@
+// @flow
+/* @jsx h */
+/* global document */
+
+import {
+    // eslint-disable-next-line
+    h,
+    render,
+    Component
+} from 'preact';
+
+const CHANGE_CARD_DELAY = 1000; // ms
+
+function getRandomCard(cards: { [CardID]: Card }): Card {
+    const ids = Object.keys(cards);
+    const randomIndex = Math.floor(Math.random() * ids.length);
+    const randomId = ids[randomIndex];
+    return cards[randomId];
+}
+
+class RandomCard extends Component<
+    {
+        cards: {
+            [CardID]: Card
+        }
+    },
+    {
+        card: Card
+    }
+> {
+    interval: IntervalID;
+
+    constructor(props) {
+        super();
+        const { cards } = props;
+        this.state = {
+            card: getRandomCard(cards)
+        };
+    }
+
+    componentDidMount() {
+        this.interval = setInterval(this.changeCard, CHANGE_CARD_DELAY);
+        // this.interval = setTimeout(this.changeCard, CHANGE_CARD_DELAY * 2);
+    }
+
+    componentWillUnmount() {
+        clearInterval(this.interval);
+    }
+
+    changeCard = () => {
+        const { cards } = this.props;
+
+        this.setState({
+            card: getRandomCard(cards)
+        });
+    };
+
+    render() {
+        const { card } = this.state;
+        return (
+            <div>
+                {card.name} <br />
+            </div>
+        );
+    }
+}
+
+function start(cards: { [CardID]: Card }) {
+    const target = document.getElementById('random-card');
+    if (target) {
+        render(<RandomCard cards={cards} />, target);
+    }
+}
+
+export { start };

--- a/website/index.js
+++ b/website/index.js
@@ -5,6 +5,7 @@
 // eslint-disable-next-line no-unused-vars
 import { createElement } from 'jsx-dom';
 import { watch } from '../core';
+import * as RandomCard from './RandomCard';
 // $FlowFixMe
 import cardInfoHeader from '../assets/tooltip-header-sprite.png';
 // $FlowFixMe
@@ -37,6 +38,8 @@ async function onLoad() {
         },
         { shouldUnderline: true }
     );
+
+    RandomCard.start(cards);
 }
 
 async function fetchJson(src: string): Promise<Object> {

--- a/website/index.js
+++ b/website/index.js
@@ -5,7 +5,6 @@
 // eslint-disable-next-line no-unused-vars
 import { createElement } from 'jsx-dom';
 import { watch } from '../core';
-import * as RandomCard from './RandomCard';
 // $FlowFixMe
 import cardInfoHeader from '../assets/tooltip-header-sprite.png';
 // $FlowFixMe
@@ -38,8 +37,6 @@ async function onLoad() {
         },
         { shouldUnderline: true }
     );
-
-    RandomCard.start(cards);
 }
 
 async function fetchJson(src: string): Promise<Object> {

--- a/website/public/index.html
+++ b/website/public/index.html
@@ -49,7 +49,7 @@
         </ul>
       </p>
 
-      <div id="random-card"></div>
+      <p id="random-card"></p>
 
       <div class="emote">
         <div class="avatar geralt"></div>

--- a/website/public/index.html
+++ b/website/public/index.html
@@ -48,6 +48,9 @@
           <li>One recruit, two recruits, three recruits...</li>
         </ul>
       </p>
+
+      <div id="random-card"></div>
+
       <div class="emote">
         <div class="avatar geralt"></div>
         <div class="emote-text">Not bad. Not bad at all.</div>

--- a/website/public/website.css
+++ b/website/public/website.css
@@ -145,3 +145,7 @@ p {
   margin-top: 0;
   margin-bottom: 3em;
 }
+
+#random-card {
+  text-align: center;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -5136,10 +5136,6 @@ performance-now@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/performance-now/-/performance-now-2.1.0.tgz#6309f4e0e5fa913ec1c69307ae364b4b377c9e7b"
 
-"perimeter@https://github.com/Soreine/perimeter.js/tarball/57381b3e6bb0a82a4d48bbe4ccb7b215276aa974/perimeter.js.tar.gz":
-  version "0.3.0"
-  resolved "https://github.com/Soreine/perimeter.js/tarball/57381b3e6bb0a82a4d48bbe4ccb7b215276aa974/perimeter.js.tar.gz#cd6563b0812c27ed808db9af88d433fbaf1bbb44"
-
 pify@^2.0.0, pify@^2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/pify/-/pify-2.3.0.tgz#ed141a6ac043a849ea588498e7dca8b15330e90c"


### PR DESCRIPTION
This properly cleanup the tooltips when the highlight is removed from the DOM. Callbacks are cleaned up. The tooltip is removed from the DOM. 👌Everything is good I hope.

This fixes a bug where if you were hovering a card name and it was removed from DOM, the tooltip would never hide.
It also avoid increasing memory usage while navigating SPAs like Reddit.com

I added a RandomCard component to test dynamic test on the website (using `yarn start`).
But it's not used in production.